### PR TITLE
suppress some compiler warnings

### DIFF
--- a/seek_to.c
+++ b/seek_to.c
@@ -1,4 +1,7 @@
 
+// for memcmp
+#include <string.h>
+
 #include "seek_to.h"
 
 // Seek to the given key and return results about the seek.


### PR DESCRIPTION
The version of gcc I run at home complains about implicit def of `memcmp`