### PR TITLE
Fix OS X snappy compilation 

### DIFF
--- a/cgo_snappy_common.go
+++ b/cgo_snappy_common.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package levigo
 
 // #cgo CFLAGS: -I${SRCDIR}/vendor/snappy -DSNAPPY


### PR DESCRIPTION
Since we started statically linking snappy, OS X compilation was broken.

We had the snappy flags in `cgo_snappy_linux.go`, but the flags work on OS X as well. I've moved the flags to a common location.