### PR TITLE
support leveldb.getmany()

### DIFF
--- a/db.go
+++ b/db.go
@@ -229,9 +229,9 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 // values, err := GetMany(ro, keys)
 // if err != nil {
 //      if mke, ok := err.(*levigo.MultiKeyError); ok {
-//          errs, indexes := mke.Errors(), mke.FailedKeyIndexes()
+//          failedIndexes, errs := mke.FailedKeyIndexes(), mke.Errors()
 //          for i := range errs {
-//              fmt.Printf("Failed for key %d, error: %s", indexes[i], errs[i])
+//              fmt.Printf("Failed for key %d, error: %s", failedIndexes[i], errs[i])
 //          }
 //      }
 // }
@@ -325,71 +325,6 @@ func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, error) {
 	}
 
 	return values, err
-}
-
-// MultiKeyError encapsulates multiple errors encountered in a Get/Put-Many() call,
-// behind the errors.error interface. Caller may cast the generic error object to
-// a MultiKeyError and call Errors() and/or FailedKeyIndexes() to get additional details.
-type MultiKeyError struct {
-	// invariant: errsByIdx is either nil or has at least ONE entry, it's never an empty map
-	errsByIdx map[int]error
-}
-
-func (mke *MultiKeyError) Error() string {
-	if mke.errsByIdx == nil {
-		return ""
-	}
-	return "Multiple keys encountered error, cast via err.(*levigo.MultiKeyErrors).Errors() to get all the errors"
-}
-
-func (mke *MultiKeyError) GoString() string {
-	return fmt.Sprintf("*%#v", *mke)
-}
-
-// FailedKeyIndexes() gives a list of indexes for which Get/PutMany() failed
-// for key at keys[indexes[i]]; e.g. if this returns[2, 3, 7], it means
-// Get/PutMany({keys[2], keys[3], keys[7]}) failed.
-func (mke *MultiKeyError) FailedKeyIndexes() []int {
-	if mke.errsByIdx == nil {
-		return nil
-	}
-
-	indexes := make([]int, 0, len(mke.errsByIdx))
-	for i := range mke.errsByIdx {
-		indexes = append(indexes, i)
-	}
-	return indexes
-}
-
-// Errors() gives specific errors failed for each key from FailedKeyIndexes()
-func (mke *MultiKeyError) Errors() []error {
-	if mke.errsByIdx == nil {
-		return nil
-	}
-
-	errs := make([]error, 0, len(mke.errsByIdx))
-	for i := range mke.errsByIdx {
-		errs = append(errs, mke.errsByIdx[i])
-	}
-	return errs
-}
-
-func (mke *MultiKeyError) addKeyErr(i int, err error) {
-	if mke.errsByIdx == nil {
-		mke.errsByIdx = make(map[int]error)
-	}
-	mke.errsByIdx[i] = err
-}
-
-func (mke *MultiKeyError) errAt(i int) error {
-	if mke.errsByIdx == nil {
-		return nil
-	}
-	err, ok := mke.errsByIdx[i]
-	if !ok {
-		return nil
-	}
-	return err
 }
 
 // Delete removes the data associated with the key from the database.

--- a/db.go
+++ b/db.go
@@ -255,7 +255,8 @@ func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, []error) {
 	}
 
 	var cPackedVals *C.char
-	var cValLens *C.size_t
+	// Must be signed int as a value could be -1 to distinguish not-found from an empty value
+	var cValLens *C.int
 	var cPackedErrs *C.char
 	var cErrLens *C.size_t
 	C.leveldb_getmany(
@@ -282,7 +283,7 @@ func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, []error) {
 	}
 
 	// Unpack the packed values from C chars into Golang byte slices
-	valueLens := (*[1 << 30]C.size_t)(unsafe.Pointer(cValLens))[:len(keys):len(keys)]
+	valueLens := (*[1 << 30]C.int)(unsafe.Pointer(cValLens))[:len(keys):len(keys)]
 	values := make([][]byte, len(keys))
 	offset = 0
 	for i := range valueLens {

--- a/db.go
+++ b/db.go
@@ -215,13 +215,15 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 	return C.GoBytes(unsafe.Pointer(value), C.int(vallen)), nil
 }
 
-// GetMany returns the values associated a list of keys from the database.
+// GetMany returns the values associated with keys from the database.
 //
-// If the key does not exist in the database, a nil []byte is returned. If the
-// key does exist, but the data is zero-length in the database, a zero-length
-// []byte will be returned.
+// GetMany fills in the entries of values consistent with Get():
+// - If keys[i] exists in the database with non-zero value, values[i] holds its non-zero len []byte slice.
+// - If keys[i] does not exist in the database, values[i] == nil.
+// - If keys[i] does exist, but its value is zero-length, values[i] == []byte{}.
+// - If there's an error looking up keys[i], values[i] == nil.
 //
-// The keys byte slice may be reused safely. Go makes a copy of
+// The keys byte slice may be reused safely. Go takes a copy of
 // them before returning.
 func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, []error) {
 	if db.closed {
@@ -236,50 +238,49 @@ func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, []error) {
 	for i := range keys {
 		packedKeysBuffer.Write(keys[i])
 		cKeyLens[i] = C.size_t(len(keys[i]))
-		for j := range keys[i] {
-			fmt.Printf("%02x", keys[i][j])
-		}
-		fmt.Printf("\n")
 	}
 	packedKeysBytes := packedKeysBuffer.Bytes()
 
 	var cPackedVals *C.char
 	var cValLens *C.size_t
 	var cPackedErrs *C.char
+	var cErrLens *C.size_t
 	C.leveldb_getmany(
-		db.Ldb, ro.Opt, (*C.char)(unsafe.Pointer(&packedKeysBytes[0])), C.size_t(len(keys)), &cKeyLens[0], &cPackedVals, &cValLens, &cPackedErrs)
+		db.Ldb, ro.Opt, (*C.char)(unsafe.Pointer(&packedKeysBytes[0])), C.size_t(len(keys)), &cKeyLens[0],
+		&cPackedVals, &cValLens,
+		&cPackedErrs, &cErrLens)
+	defer C.leveldb_free(unsafe.Pointer(cPackedErrs))
+	defer C.leveldb_free(unsafe.Pointer(cErrLens))
+	defer C.leveldb_free(unsafe.Pointer(cPackedVals))
+	defer C.leveldb_free(unsafe.Pointer(cValLens))
 
-	valueLens := (*[1 << 30]C.size_t)(unsafe.Pointer(cValLens))[:len(keys):len(keys)]
-
-	// Unpack the packed values from C into Golang byte slices
-	values := make([][]byte, len(keys))
+	// Unpack the errors from C chars into Golang error objects
+	errLens := (*[1 << 30]C.size_t)(unsafe.Pointer(cErrLens))[:len(keys):len(keys)]
 	errs := make([]error, len(keys))
 	offset := 0
+	for i := range errLens {
+		if errLens[i] == 0 {
+			continue
+		}
+		b := C.GoBytes(unsafe.Pointer(uintptr(unsafe.Pointer(cPackedErrs))+uintptr(offset)), C.int(errLens[i]))
+		errStrLen := int(errLens[i])
+		errs[i] = fmt.Errorf(string(b[:errStrLen]))
+		offset += errStrLen
+	}
+
+	// Unpack the packed values from C chars into Golang byte slices
+	valueLens := (*[1 << 30]C.size_t)(unsafe.Pointer(cValLens))[:len(keys):len(keys)]
+	values := make([][]byte, len(keys))
+	offset = 0
 	for i := range valueLens {
 		if valueLens[i] > 0 {
 			values[i] = C.GoBytes(unsafe.Pointer(uintptr(unsafe.Pointer(cPackedVals))+uintptr(offset)), C.int(valueLens[i]))
 			offset += int(valueLens[i])
-		} else if valueLens[i] == 0 {
-			// keys[i] is found but with empty value
+		} else if errs[i] == nil && valueLens[i] == 0 {
+			// No error and no value, it means keys[i] is found but with empty value
 			values[i] = []byte{}
-		} else {
-			// -1 means not found
-			values[i] = nil
 		}
-
-		/*
-			if cErrs[i] != nil {
-				gs := C.GoString(cErrs[i])
-				C.leveldb_free(unsafe.Pointer(cErrs[i]))
-				errs[i] = DatabaseError(gs)
-			}
-
-		*/
 	}
-
-	C.leveldb_free(unsafe.Pointer(cPackedVals))
-	C.leveldb_free(unsafe.Pointer(cValLens))
-	//C.leveldb_free(unsafe.Pointer(&cErrs))
 
 	return values, errs
 }

--- a/db.go
+++ b/db.go
@@ -230,8 +230,8 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 // if err != nil {
 //      if mke, ok := err.(*levigo.MultiKeyError); ok {
 //          errsByKeyIdx := mke.ErrorsByKeyIdx()
-//          for idx := range errsByKeyIdx {
-//              fmt.Printf("Failed for key %s, error: %s", keys[idx], errs[i])
+//          for idx, err := range errsByKeyIdx {
+//              fmt.Printf("Failed for key %s, error: %s", keys[idx], err)
 //          }
 //      }
 // }

--- a/db.go
+++ b/db.go
@@ -255,7 +255,6 @@ func (db *DB) GetMany(ro *ReadOptions, keys [][]byte) ([][]byte, []error) {
 	}
 
 	var cPackedVals *C.char
-	// Must be signed int as a value could be -1 to distinguish not-found from an empty value
 	var cValLens *C.int
 	var cPackedErrs *C.char
 	var cErrLens *C.size_t

--- a/db.go
+++ b/db.go
@@ -229,9 +229,9 @@ func (db *DB) Get(ro *ReadOptions, key []byte) ([]byte, error) {
 // values, err := GetMany(ro, keys)
 // if err != nil {
 //      if mke, ok := err.(*levigo.MultiKeyError); ok {
-//          failedIndexes, errs := mke.FailedKeyIndexes(), mke.Errors()
-//          for i := range errs {
-//              fmt.Printf("Failed for key %d, error: %s", failedIndexes[i], errs[i])
+//          errsByKeyIdx := mke.ErrorsByKeyIdx()
+//          for idx := range errsByKeyIdx {
+//              fmt.Printf("Failed for key %s, error: %s", keys[idx], errs[i])
 //          }
 //      }
 // }

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -257,11 +257,11 @@ void leveldb_getmany(
     }
   }
 
-  // cgo only support simple type conversions from c go to for int/chars
-  // and simple linear array of such types. To pass back multiple values,
-  // we pack all of them into one malloc()-ed byte array packed_vals, 
-  // with an array of offsets, vallens. Caller can use them together
-  // to unpack the values
+  // cgo only support simple type conversions between c<->go for int/char
+  // and simple linear array of ints/chars. To pass back multiple values
+  // (arrays of char arrays), we pack all of them into one malloc()-ed char
+  // array, `packed_vals`, with an array of offsets, `vallens`. Caller can then
+  // use them together to unpack the values
   int offset = 0;
   *packed_vals = reinterpret_cast<char*>(malloc(packed_vals_len));
   for (int i = 0; i < values.size(); i++) {

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -257,7 +257,7 @@ void leveldb_getmany(
     }
   }
 
-  // cgo only support simple type conversions between c<->go for int/char
+  // cgo only supports simple type conversions between c<->go for int/char
   // and simple linear array of ints/chars. To pass back multiple values
   // (arrays of char arrays), we pack all of them into one malloc()-ed char
   // array, `packed_vals`, with an array of offsets, `vallens`. Caller can then

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -222,7 +222,7 @@ void leveldb_getmany(
     size_t num_keys,
     const size_t* keylens,
     char** packed_vals,
-    int** vallens, // value must be signed int as it could be -1 to distinguish not-found from an empty value
+    int** vallens, // must be signed int as (*vallens)[i] could be set to -1 to distinguish not-found from an empty value
     char** packed_errs,
     size_t** errlens) {
   // These, along with packed_vals and packed_errs are out-params malloc()-ed from 

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -228,20 +228,19 @@ void leveldb_getmany(
   // These, along with packed_vals and packed_errs are out-params malloc()-ed from 
   // the heap which the caller in go-land should free via C.leveldb_free()
   *vallens = reinterpret_cast<int*>(malloc(sizeof(int) * num_keys));
-  *errlens = reinterpret_cast<size_t*>(malloc(sizeof(size_t) * num_keys));
 
   int key_offset = 0;
   std::vector<std::string> values(num_keys);
   int packed_vals_len = 0;
-  std::vector<std::string> errs(num_keys);
+  std::vector<std::string> errs;
   int packed_errs_len = 0;
+
   for (int i = 0; i < num_keys; i++) {
     Slice key(const_cast<char*>(&(packed_keys[key_offset])), keylens[i]);
     key_offset += keylens[i];
 
     Status s = db->rep->Get(options->rep, key, &(values[i]));
     (*vallens)[i] = 0;
-    (*errlens)[i] = 0;
     if (s.ok()) {
       (*vallens)[i] = values[i].size();
       packed_vals_len += values[i].size();
@@ -250,9 +249,19 @@ void leveldb_getmany(
         // Key is not in db, not an error
         (*vallens)[i] = -1;
       } else {
-        errs[i] = s.ToString();
-        (*errlens)[i] = errs[i].length();
-        packed_errs_len += errs[i].length();
+        std::string errStr = s.ToString();
+        // Most of the time getmany won't experience any error for any
+        // of the keys so we can avoid the cost of allocation and only
+        // lazy-initialize if there's at least one error
+        if (errs.empty()) {
+          *errlens = reinterpret_cast<size_t*>(malloc(sizeof(size_t) * num_keys));
+          // All errlens[i] and errs[i] must be properly initialized, to 0 and ""
+          memset(*errlens, 0, sizeof(size_t) * num_keys);
+          errs = std::vector<std::string>(num_keys);
+        }
+        errs[i] = errStr;
+        (*errlens)[i] = errStr.length();
+        packed_errs_len += errStr.length();
       }
     }
   }
@@ -263,12 +272,17 @@ void leveldb_getmany(
   // array, `packed_vals`, with an array of offsets, `vallens`. Caller can then
   // use them together to unpack the values
   int offset = 0;
-  *packed_vals = reinterpret_cast<char*>(malloc(packed_vals_len));
-  for (int i = 0; i < values.size(); i++) {
-    if (values[i].length() > 0) {
-      memcpy(&((*packed_vals)[offset]), values[i].data(), values[i].length());
-      offset += values[i].length();
+  if (packed_vals_len > 0) {
+    *packed_vals = reinterpret_cast<char*>(malloc(packed_vals_len));
+    for (int i = 0; i < values.size(); i++) {
+      if (values[i].length() > 0) {
+        memcpy(&((*packed_vals)[offset]), values[i].data(), values[i].length());
+        offset += values[i].length();
+      }
     }
+  } else {
+    // Either all gets failed or the values of all keys is the empty byte array
+     *packed_vals = NULL;
   }
 
   // Do the same for errors
@@ -281,6 +295,9 @@ void leveldb_getmany(
         offset += errs[i].length();
       }
     }
+  } else {
+    // Caller can use (*packed_errs == NULL) as a sign that there were no errors
+    *packed_errs = NULL;
   }
 }
 

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -222,12 +222,12 @@ void leveldb_getmany(
     size_t num_keys,
     const size_t* keylens,
     char** packed_vals,
-    size_t** vallens,
+    int** vallens, // value must be signed int as it could be -1 to distinguish not-found from an empty value
     char** packed_errs,
     size_t** errlens) {
   // These, along with packed_vals and packed_errs are out-params malloc()-ed from 
   // the heap which the caller in go-land should free via C.leveldb_free()
-  *vallens = reinterpret_cast<size_t*>(malloc(sizeof(size_t) * num_keys));
+  *vallens = reinterpret_cast<int*>(malloc(sizeof(int) * num_keys));
   *errlens = reinterpret_cast<size_t*>(malloc(sizeof(size_t) * num_keys));
 
   int key_offset = 0;

--- a/deps/leveldb/include/leveldb/c.h
+++ b/deps/leveldb/include/leveldb/c.h
@@ -104,6 +104,16 @@ extern char* leveldb_get(
     size_t* vallen,
     char** errptr);
 
+extern void leveldb_getmany(
+    leveldb_t* db,
+    const leveldb_readoptions_t* options,
+    const char* packed_keys,
+    size_t num_keys,
+    const size_t* keylens,
+    char** packed_vals,
+    size_t** vallens,
+    char** packed_errs);
+
 extern leveldb_iterator_t* leveldb_create_iterator(
     leveldb_t* db,
     const leveldb_readoptions_t* options);

--- a/deps/leveldb/include/leveldb/c.h
+++ b/deps/leveldb/include/leveldb/c.h
@@ -112,7 +112,8 @@ extern void leveldb_getmany(
     const size_t* keylens,
     char** packed_vals,
     size_t** vallens,
-    char** packed_errs);
+    char** packed_errs,
+    size_t** errlens);
 
 extern leveldb_iterator_t* leveldb_create_iterator(
     leveldb_t* db,

--- a/deps/leveldb/include/leveldb/c.h
+++ b/deps/leveldb/include/leveldb/c.h
@@ -111,7 +111,7 @@ extern void leveldb_getmany(
     size_t num_keys,
     const size_t* keylens,
     char** packed_vals,
-    size_t** vallens,
+    int** vallens,
     char** packed_errs,
     size_t** errlens);
 

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -434,23 +435,17 @@ func TestDBGetMany(t *testing.T) {
 var useGetMany = flag.Bool("_ldb_usegetmany", true, "By default uses uses GetMany() in favor of multiple calls of Get()")
 
 func BenchmarkDBGets(b *testing.B) {
-	// We only want a reasonably available path to hold the new db
-	tmpPath := filepath.Join(os.TempDir(), fmt.Sprintf("levigo-benchmark-dbgets-%d", rand.Int()))
-	// We'll be putting a db in its place
-	os.RemoveAll(tmpPath)
-
+	dbname := ioutil.TempDir("", "levigo-benchmark-")
 	options := NewOptions()
 	options.SetErrorIfExists(true)
 	options.SetCreateIfMissing(true)
 	ro := NewReadOptions()
 	wo := NewWriteOptions()
-	dbname := tmpPath
-	_ = DestroyDatabase(dbname, options)
 	db, err := Open(dbname, options)
-	defer os.RemoveAll(dbname)
 	if err != nil {
 		b.Fatalf("Database could not be opened: %v", err)
 	}
+	defer os.RemoveAll(dbname)
 	defer db.Close()
 
 	// Populate the db with some test key-value pairs

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -455,7 +455,7 @@ func BenchmarkDBGets(b *testing.B) {
 
 	// Populate the db with some test key-value pairs
 	const fixedKeyLen = 20
-	const fixedValueLen = 256
+	const fixedValueLen = 128
 	keys := make([][]byte, 10000)
 	expectedValues := make([][]byte, len(keys))
 	nb := 0

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -429,12 +429,15 @@ func TestDBGetMany(t *testing.T) {
 }
 
 func BenchmarkDBGets(b *testing.B) {
-	b.Run("SingleGet", func(b *testing.B) { benchmarkDBGets(b, false) })
-	b.Run("MultiGet", func(b *testing.B) { benchmarkDBGets(b, true) })
+	b.Run("multiple-Get()s", func(b *testing.B) { benchmarkDBGets(b, false) })
+	b.Run("one-GetMany()", func(b *testing.B) { benchmarkDBGets(b, true) })
 }
 
 func benchmarkDBGets(b *testing.B, useGetMany bool) {
-	dbname := ioutil.TempDir("", "levigo-benchmark-")
+	dbname, err := ioutil.TempDir("", "levigo-benchmark-")
+	if err != nil {
+		b.Fatalf("Failed to create db for benchmark")
+	}
 	options := NewOptions()
 	options.SetErrorIfExists(true)
 	options.SetCreateIfMissing(true)

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -465,6 +465,7 @@ func BenchmarkDBGets(b *testing.B) {
 		if n != len(keys[i]) || err != nil {
 			b.Fatalf("could not generate random keys")
 		}
+		expectedValues[i] = make([]byte, fixedValueLen)
 		n, err = rand.Read(expectedValues[i])
 		if n != len(expectedValues[i]) || err != nil {
 			b.Fatalf("could not generate random values")

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -2,7 +2,6 @@ package levigo
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -429,12 +428,12 @@ func TestDBGetMany(t *testing.T) {
 	}
 }
 
-// To get the benchmarks of multiple DB gets using Get() instead of the
-// GetMany() API, disable the flag like so:
-// go test -count=2 -run=^$ -bench=BenchmarkDBGets -_ldb_usegetmany=false
-var useGetMany = flag.Bool("_ldb_usegetmany", true, "By default uses uses GetMany() in favor of multiple calls of Get()")
-
 func BenchmarkDBGets(b *testing.B) {
+	b.Run("SingleGet", func(b *testing.B) { benchmarkDBGets(b, false) })
+	b.Run("MultiGet", func(b *testing.B) { benchmarkDBGets(b, true) })
+}
+
+func benchmarkDBGets(b *testing.B, useGetMany bool) {
 	dbname := ioutil.TempDir("", "levigo-benchmark-")
 	options := NewOptions()
 	options.SetErrorIfExists(true)
@@ -476,7 +475,7 @@ func BenchmarkDBGets(b *testing.B) {
 	b.SetBytes(int64(nb))
 
 	for i := 0; i < b.N; i++ {
-		if *useGetMany {
+		if useGetMany {
 			values, _ := db.GetMany(ro, keys)
 			runtime.KeepAlive(values)
 		} else {

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -471,6 +471,7 @@ func TestMultiKeyErrors(t *testing.T) {
 	if len(errs) != len(indexes) {
 		t.Errorf("expecting len(errs) == len(indexes)")
 	}
+	t.Logf("multikey-error content: %s", mke.Error())
 	for i := range errs {
 		if errs[i] == nil {
 			t.Errorf("Expecting error at %d", i)

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -343,7 +343,7 @@ func TestDBGetMany(t *testing.T) {
 		[]byte("hello world3"),
 		[]byte{}, // Yes an empty byte slice as key is valid
 		[]byte("hello world4"),
-		[]byte{}, // yes a nil key is also valid, it's interpreted as an empty byte slice
+		nil, // yes a nil key is also valid, it's interpreted as an empty byte slice
 	}
 
 	emptyKeyValue := []byte("value for empty key")

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -2,6 +2,7 @@ package levigo
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -371,8 +372,9 @@ func TestDBGetMany(t *testing.T) {
 		}
 	}
 
-	values, errs := db.GetMany(ro, keys)
-	if errs != nil {
+	var values [][]byte
+	values, err = db.GetMany(ro, keys)
+	if err != nil {
 		t.Errorf("expecting all gets succeeded")
 	}
 	if len(values) != len(keys) {
@@ -390,8 +392,8 @@ func TestDBGetMany(t *testing.T) {
 		[]byte{}, // Yes an empty byte slice as key is valid
 		[]byte("hello world5-NOT_FOUND"),
 	}
-	values, errs = db.GetMany(ro, keys2)
-	if errs != nil {
+	values, err = db.GetMany(ro, keys2)
+	if err != nil {
 		t.Errorf("expecting all gets succeeded")
 	}
 	if len(values) != len(keys2) {
@@ -411,16 +413,16 @@ func TestDBGetMany(t *testing.T) {
 		t.Errorf("Expecting non-existant key to return value of nil")
 	}
 
-	values, errs = db.GetMany(ro, nil)
-	if values != nil || errs != nil {
+	values, err = db.GetMany(ro, nil)
+	if values != nil || err != nil {
 		t.Errorf("GetMany(): on nil slice should return nil, nil")
 	}
 
 	// Calling GetMany on a slice of N nil slices will be interpreted
 	// as N Gets of the same empty key
 	emptyKeys := make([][]byte, 10)
-	values, errs = db.GetMany(ro, emptyKeys)
-	if errs != nil {
+	values, err = db.GetMany(ro, emptyKeys)
+	if err != nil {
 		t.Errorf("expecting all gets succeeded")
 	}
 	if len(values) != len(emptyKeys) {
@@ -434,8 +436,8 @@ func TestDBGetMany(t *testing.T) {
 
 	// Also verify GetMany with keys all of whose values are the empty value
 	keysWithEmptyValues := [][]byte{keyWithEmptyValue, keyWithEmptyValue, keyWithEmptyValue}
-	emptyValues, errs := db.GetMany(ro, keysWithEmptyValues)
-	if errs != nil {
+	emptyValues, err := db.GetMany(ro, keysWithEmptyValues)
+	if err != nil {
 		t.Errorf("expecting all gets succeeded")
 	}
 	if len(emptyValues) != len(keysWithEmptyValues) {
@@ -448,6 +450,34 @@ func TestDBGetMany(t *testing.T) {
 	}
 }
 
+func TestMultiKeyErrors(t *testing.T) {
+	mke := &MultiKeyError{}
+	mke.addKeyErr(2, errors.New("Error foo"))
+	mke.addKeyErr(5, errors.New("Error bar"))
+	mke.addKeyErr(7, errors.New("Error fooz"))
+	var err error = mke
+	_, ok := err.(*MultiKeyError)
+	if !ok {
+		t.Errorf("type assertion failed")
+	}
+
+	errs, indexes := mke.Errors(), mke.FailedKeyIndexes()
+	if errs == nil || len(errs) == 0 {
+		t.Errorf("expecting errors")
+	}
+	if indexes == nil || len(indexes) == 0 {
+		t.Errorf("expecting failed indexes")
+	}
+	if len(errs) != len(indexes) {
+		t.Errorf("expecting len(errs) == len(indexes)")
+	}
+	for i := range errs {
+		if errs[i] == nil {
+			t.Errorf("Expecting error at %d", i)
+		}
+		t.Logf("For key %d, packed error: %s", indexes[i], errs[i])
+	}
+}
 func BenchmarkDBGets(b *testing.B) {
 	b.Run("multiple-Get()s", func(b *testing.B) { benchmarkDBGets(b, false) })
 	b.Run("one-GetMany()", func(b *testing.B) { benchmarkDBGets(b, true) })

--- a/multikey_error.go
+++ b/multikey_error.go
@@ -1,0 +1,82 @@
+package levigo
+
+import (
+	"fmt"
+)
+
+// MultiKeyError encapsulates multiple errors encountered in a Get/Put-Many() call,
+// behind the errors.error interface. Caller may cast the generic error object to
+// a MultiKeyError and call Errors() and/or FailedKeyIndexes() to get additional details.
+type MultiKeyError struct {
+	// invariant: errsByIdx is either nil or has at least ONE entry, it's never an empty map
+	errsByIdx map[int]error
+}
+
+func (mke *MultiKeyError) Error() string {
+	if mke.errsByIdx == nil {
+		return ""
+	}
+
+	// Show a few errors to informed the user
+	var topErrsMsg string
+	const maxNumErrs = 3
+	cnt := 0
+	for i := range mke.errsByIdx {
+		topErrsMsg += fmt.Sprintf(" keys[%d]:%s;", i, mke.errsByIdx[i].Error())
+		cnt++
+		if cnt >= maxNumErrs {
+			break
+		}
+	}
+	return fmt.Sprintf("%d keys encountered error (here's a few:%s), cast via err.(*levigo.MultiKeyErrors).Errors() to get all the errors", len(mke.errsByIdx), topErrsMsg)
+}
+
+func (mke *MultiKeyError) GoString() string {
+	return fmt.Sprintf("*%#v", *mke)
+}
+
+// FailedKeyIndexes() gives a list of indexes for which Get/PutMany() failed
+// for key at keys[indexes[i]]; e.g. if this returns[2, 3, 7], it means
+// Get/PutMany({keys[2], keys[3], keys[7]}) failed.
+func (mke *MultiKeyError) FailedKeyIndexes() []int {
+	if mke.errsByIdx == nil {
+		return nil
+	}
+
+	indexes := make([]int, 0, len(mke.errsByIdx))
+	for i := range mke.errsByIdx {
+		indexes = append(indexes, i)
+	}
+	return indexes
+}
+
+// Errors() gives specific errors failed for each key from FailedKeyIndexes()
+func (mke *MultiKeyError) Errors() []error {
+	if mke.errsByIdx == nil {
+		return nil
+	}
+
+	errs := make([]error, 0, len(mke.errsByIdx))
+	for i := range mke.errsByIdx {
+		errs = append(errs, mke.errsByIdx[i])
+	}
+	return errs
+}
+
+func (mke *MultiKeyError) addKeyErr(i int, err error) {
+	if mke.errsByIdx == nil {
+		mke.errsByIdx = make(map[int]error)
+	}
+	mke.errsByIdx[i] = err
+}
+
+func (mke *MultiKeyError) errAt(i int) error {
+	if mke.errsByIdx == nil {
+		return nil
+	}
+	err, ok := mke.errsByIdx[i]
+	if !ok {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
This adds the `GetMany()` API to our forked version of leveldb directly. This should be faster than calling `Get()` in go in a loop as each such call crossing go-to-c-and-back can be expensive in cgo. 

According to the benchmarks below, and if I am interpreting them correctly, `GetMany()` is about *20% faster* cpu-wise, and *25% higher* in i/o throughput than `Get()`, using fixed-key length of 20 bytes and fixed-value length of 128 bytes.

```
name             old time/op    new time/op    delta
DBGets/DBGets-2    14.2ms ± 8%    11.4ms ± 6%  -20.16%  (p=0.000 n=10+9)
name             old speed      new speed      delta
DBGets/DBGets-2  14.1MB/s ± 8%  17.6MB/s ± 6%  +25.08%  (p=0.000 n=10+9)
```