### PR TITLE
[leveldb] Add support for PutMany()

### DIFF
--- a/deps/leveldb/include/leveldb/c.h
+++ b/deps/leveldb/include/leveldb/c.h
@@ -83,6 +83,17 @@ extern void leveldb_put(
     const char* val, size_t vallen,
     char** errptr);
 
+extern void leveldb_putmany(
+    leveldb_t* db,
+    const leveldb_writeoptions_t* options,
+    size_t num_keys,
+    const char* packed_keys,
+    const size_t* keylens,
+    const char* packed_vals,
+    const size_t* vals_lens,
+    char** packed_errs,
+    size_t** errlens);
+
 extern void leveldb_delete(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -378,10 +378,8 @@ func TestDBPutManyGetMany(t *testing.T) {
 
 	// Populate the db with some test key-value pairs
 	errs = db.PutMany(wo, keys, expectedValues)
-	for i := range errs {
-		if errs[i] != nil {
-			t.Errorf("PutMany() failed for key[%d]: %v", i, errs[i])
-		}
+	if errs != nil {
+		t.Errorf("PutMany() should not fail for any keys")
 	}
 
 	values, errs := db.GetMany(ro, keys)
@@ -457,60 +455,6 @@ func TestDBPutManyGetMany(t *testing.T) {
 	for i := range emptyValues {
 		if emptyValues[i] == nil || len(emptyValues[i]) != 0 {
 			t.Errorf("expecting a zero-length, non-nil, empty-value for key %d", i)
-		}
-	}
-}
-func TestMemLeak(t *testing.T) {
-	dbname, err := ioutil.TempDir("", "levigo-memleak-")
-	if err != nil {
-		t.Fatalf("Failed to create db to run test")
-	}
-	options := NewOptions()
-	options.SetErrorIfExists(true)
-	options.SetCreateIfMissing(true)
-	ro := NewReadOptions()
-	wo := NewWriteOptions()
-	db, err := Open(dbname, options)
-	defer os.RemoveAll(dbname)
-	if err != nil {
-		t.Fatalf("Database could not be opened: %v", err)
-	}
-	defer db.Close()
-
-	// Populate the db with some test key-value pairs
-	const fixedKeyLen = 20
-	const fixedValueLen = 1024 * 1024
-	keys := make([][]byte, 10000)
-	expectedValues := make([][]byte, len(keys))
-	for i := range keys {
-		keys[i] = make([]byte, fixedKeyLen)
-		n, err := rand.Read(keys[i])
-		if n != len(keys[i]) || err != nil {
-			t.Fatalf("could not generate random keys")
-		}
-		expectedValues[i] = make([]byte, fixedValueLen)
-		n, err = rand.Read(expectedValues[i])
-		if n != len(expectedValues[i]) || err != nil {
-			t.Fatalf("could not generate random values")
-		}
-		err = db.Put(wo, keys[i], expectedValues[i])
-		if err != nil {
-			t.Errorf("Put failed: %v", err)
-		}
-	}
-
-	nb := 0
-	round := 0
-	fmt.Printf("Alloced:\n")
-	for {
-		round++
-
-		values, _ := db.GetMany(ro, keys)
-		for k := range values {
-			nb += len(values[k])
-		}
-		if round%1000 == 0 {
-			fmt.Printf("%d\n", nb)
 		}
 	}
 }

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -380,7 +380,7 @@ func TestDBPutManyGetMany(t *testing.T) {
 	// Populate the db with some test key-value pairs
 	err = db.PutMany(wo, keys, expectedValues)
 	if err != nil {
-		t.Errorf("PutMany() should not fail for any keys")
+		t.Errorf("PutMany() should not fail for any key, error: %s", err)
 	}
 
 	var values [][]byte
@@ -508,10 +508,10 @@ func benchmarkDBGets(b *testing.B, useGetMany bool) {
 	ro := NewReadOptions()
 	wo := NewWriteOptions()
 	db, err := Open(dbname, options)
+	defer os.RemoveAll(dbname)
 	if err != nil {
 		b.Fatalf("Database could not be opened: %v", err)
 	}
-	defer os.RemoveAll(dbname)
 	defer db.Close()
 
 	// Populate the db with some test key-value pairs
@@ -569,10 +569,10 @@ func benchmarkDBPuts(b *testing.B, usePutMany bool) {
 	options.SetCreateIfMissing(true)
 	wo := NewWriteOptions()
 	db, err := Open(dbname, options)
+	defer os.RemoveAll(dbname)
 	if err != nil {
 		b.Fatalf("Database could not be opened: %v", err)
 	}
-	defer os.RemoveAll(dbname)
 	defer db.Close()
 
 	const fixedKeyLen = 20


### PR DESCRIPTION
Rinse and repeat of `GetMany()`: https://github.com/DataDog/leveldb/pull/10

This adds the `PutMany()` API to our forked version of leveldb directly. This should be faster than calling `Put()` in go in a loop as each such call crossing go-to-c-and-back can be expensive in cgo. 

Although according to the benchmark it is hardly faster:
```
name                      time/op
DBPuts/multiple-Put()s-2    40.2ms ±12%
DBPuts/one-Multiput()-2     41.7ms ± 7%

name                      speed
DBPuts/multiple-Put()s-2  36.9MB/s ±11%
DBPuts/one-Multiput()-2   35.5MB/s ± 7%
```