### PR TITLE
Use struct initialization to ensure values are zero-initialized

### DIFF
--- a/seek_to.c
+++ b/seek_to.c
@@ -8,7 +8,7 @@
 SeekResult leveldb_iter_seek_to(leveldb_iterator_t* iter, const char* k, size_t klen) {
     leveldb_iter_seek(iter, k, klen);
 
-    SeekResult sr;
+    SeekResult sr = {};
     sr.valid = leveldb_iter_valid(iter);
 
     if (sr.valid != 0) {

--- a/seek_to.c
+++ b/seek_to.c
@@ -8,7 +8,7 @@
 SeekResult leveldb_iter_seek_to(leveldb_iterator_t* iter, const char* k, size_t klen) {
     leveldb_iter_seek(iter, k, klen);
 
-    SeekResult sr = {};
+    SeekResult sr = {0};
     sr.valid = leveldb_iter_valid(iter);
 
     if (sr.valid != 0) {


### PR DESCRIPTION
In `seek_to.go`, we are unconditionally reading from `out.equal` but we are only
conditionally setting `out.equal` in `seek_to.c`. We could fix the bug by only
zeroing out the two fields that are unconditionally read, but zeroing out stack
memory is pretty cheap, so I'm erring on the safe side by initializing the whole
struct.