### PR TITLE
Small changes to #10 to use safer patterns

### DIFF
--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -229,13 +229,13 @@ void leveldb_getmany(
   // the heap which the caller in go-land should free via C.leveldb_free()
   *vallens = reinterpret_cast<int*>(malloc(sizeof(int) * num_keys));
 
-  int key_offset = 0;
+  size_t key_offset = 0;
   std::vector<std::string> values(num_keys);
-  int packed_vals_len = 0;
+  size_t packed_vals_len = 0;
   std::vector<std::string> errs;
-  int packed_errs_len = 0;
+  size_t packed_errs_len = 0;
 
-  for (int i = 0; i < num_keys; i++) {
+  for (size_t i = 0; i < num_keys; i++) {
     Slice key(&(packed_keys[key_offset]), keylens[i]);
     key_offset += keylens[i];
 
@@ -272,13 +272,13 @@ void leveldb_getmany(
   // (arrays of char arrays), we pack all of them into one malloc()-ed char
   // array, `packed_vals`, with an array of offsets, `vallens`. Caller can then
   // use them together to unpack the values
-  int offset = 0;
   if (packed_vals_len > 0) {
     *packed_vals = reinterpret_cast<char*>(malloc(packed_vals_len));
-    for (int i = 0; i < values.size(); i++) {
-      if (values[i].length() > 0) {
-        memcpy(&((*packed_vals)[offset]), values[i].data(), values[i].length());
-        offset += values[i].length();
+    size_t offset = 0;
+    for (const auto& value : values) {
+      if (value.length() > 0) {
+        memcpy(&((*packed_vals)[offset]), value.data(), value.length());
+        offset += value.length();
       }
     }
   } else {
@@ -287,13 +287,13 @@ void leveldb_getmany(
   }
 
   // Do the same for errors
-  offset = 0;
   if (packed_errs_len > 0) {
     *packed_errs = reinterpret_cast<char*>(malloc(packed_errs_len));
-    for (int i = 0; i < errs.size(); i++) {
-      if (errs[i].length() > 0) {
-        memcpy(&((*packed_errs)[offset]), errs[i].data(), errs[i].length());
-        offset += errs[i].length();
+    size_t offset = 0;
+    for (const auto& err : errs) {
+      if (err.length() > 0) {
+        memcpy(&((*packed_errs)[offset]), err.data(), err.length());
+        offset += err.length();
       }
     }
   } else {

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -259,9 +259,10 @@ void leveldb_getmany(
           memset(*errlens, 0, sizeof(size_t) * num_keys);
           errs = std::vector<std::string>(num_keys);
         }
-        errs[i] = errStr;
-        (*errlens)[i] = errStr.length();
-        packed_errs_len += errStr.length();
+        size_t len = errStr.length();
+        errs[i] = std::move(errStr);
+        (*errlens)[i] = len;
+        packed_errs_len += len;
       }
     }
   }

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -225,7 +225,7 @@ void leveldb_getmany(
     int** vallens, // must be signed int as (*vallens)[i] could be set to -1 to distinguish not-found from an empty value
     char** packed_errs,
     size_t** errlens) {
-  // These, along with packed_vals and packed_errs are out-params malloc()-ed from 
+  // These, along with packed_vals and packed_errs are out-params malloc()-ed from
   // the heap which the caller in go-land should free via C.leveldb_free()
   *vallens = reinterpret_cast<int*>(malloc(sizeof(int) * num_keys));
 
@@ -236,7 +236,7 @@ void leveldb_getmany(
   int packed_errs_len = 0;
 
   for (int i = 0; i < num_keys; i++) {
-    Slice key(const_cast<char*>(&(packed_keys[key_offset])), keylens[i]);
+    Slice key(&(packed_keys[key_offset]), keylens[i]);
     key_offset += keylens[i];
 
     Status s = db->rep->Get(options->rep, key, &(values[i]));


### PR DESCRIPTION
Outside of the risk of `GetMany` returning more than 2 GB of values or errors which would trigger UB, I don't think any of these changes fix bugs. They're just small changes to reflect best practices.