### PR TITLE
Reduce Go heap allocations

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -55,16 +55,15 @@ func (it *Iterator) Valid() bool {
 //
 // If Valid returns false, this method will panic.
 func (it *Iterator) Key() []byte {
-	var klen C.size_t
-	kdata := C.leveldb_iter_key(it.Iter, &klen)
-	if kdata == nil {
+	result := C.leveldb_iter_key(it.Iter)
+	if result.data == nil {
 		return nil
 	}
-	// Unlike DB.Get, the key, kdata, returned is not meant to be freed by the
+	// Unlike DB.Get, the key, result.data, returned is not meant to be freed by the
 	// client. It's a direct reference to data managed by the iterator_t
 	// instead of a copy.  So, we must not free it here but simply copy it
 	// with GoBytes.
-	return C.GoBytes(unsafe.Pointer(kdata), C.int(klen))
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.len))
 }
 
 // Value returns a copy of the value in the database the iterator currently
@@ -72,16 +71,15 @@ func (it *Iterator) Key() []byte {
 //
 // If Valid returns false, this method will panic.
 func (it *Iterator) Value() []byte {
-	var vlen C.size_t
-	vdata := C.leveldb_iter_value(it.Iter, &vlen)
-	if vdata == nil {
+	result := C.leveldb_iter_value(it.Iter)
+	if result.data == nil {
 		return nil
 	}
-	// Unlike DB.Get, the value, vdata, returned is not meant to be freed by
+	// Unlike DB.Get, the value, result.data, returned is not meant to be freed by
 	// the client. It's a direct reference to data managed by the iterator_t
 	// instead of a copy. So, we must not free it here but simply copy it with
 	// GoBytes.
-	return C.GoBytes(unsafe.Pointer(vdata), C.int(vlen))
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.len))
 }
 
 // Next moves the iterator to the next sequential key in the database, as
@@ -130,8 +128,7 @@ func (it *Iterator) Seek(key []byte) {
 //
 // This method is safe to call when Valid returns false.
 func (it *Iterator) GetError() error {
-	var errStr *C.char
-	C.leveldb_iter_get_error(it.Iter, &errStr)
+	errStr := C.leveldb_iter_get_error(it.Iter)
 	if errStr != nil {
 		gs := C.GoString(errStr)
 		C.leveldb_free(unsafe.Pointer(errStr))

--- a/leveldb_test.go
+++ b/leveldb_test.go
@@ -495,7 +495,9 @@ func benchmarkDBGets(b *testing.B, useGetMany bool) {
 	options.SetErrorIfExists(true)
 	options.SetCreateIfMissing(true)
 	ro := NewReadOptions()
+	defer ro.Close()
 	wo := NewWriteOptions()
+	defer wo.Close()
 	db, err := Open(dbname, options)
 	if err != nil {
 		b.Fatalf("Database could not be opened: %v", err)

--- a/seek_to.c
+++ b/seek_to.c
@@ -13,14 +13,15 @@ SeekResult leveldb_iter_seek_to(leveldb_iterator_t* iter, const char* k, size_t 
 
     if (sr.valid != 0) {
         // if we have a valid result, fetch the key
-        size_t out_key_len;
-        const char* out_key = leveldb_iter_key(iter, &out_key_len);
+        leveldb_slice_t out_key = leveldb_iter_key(iter);
 
-        sr.equal = ((klen == out_key_len) && (memcmp(k, out_key, klen) == 0));
+        sr.equal = ((klen == out_key.len) && (memcmp(k, out_key.data, klen) == 0));
 
         // if the key is equal also fetch the value.
         if (sr.equal != 0) {
-            sr.val_data = leveldb_iter_value(iter, &sr.val_len);
+            leveldb_slice_t val_out = leveldb_iter_value(iter);
+            sr.val_data = val_out.data;
+            sr.val_len = val_out.len;
         }
     }
 
@@ -35,8 +36,7 @@ unsigned char leveldb_iter_exists(leveldb_iterator_t* iter, const char* k, size_
         return 0;
     }
 
-    size_t out_key_len;
-    const char* out_key = leveldb_iter_key(iter, &out_key_len);
+    leveldb_slice_t out_key = leveldb_iter_key(iter);
 
-    return ((klen == out_key_len) && (memcmp(k, out_key, klen) == 0));
+    return ((klen == out_key.len) && (memcmp(k, out_key.data, klen) == 0));
 }


### PR DESCRIPTION
Reduces Go heap allocations. Changes LevelDB C API to return results by value instead of by argument pointers (pointers passed to cgo escape).

Heap allocations go down from 4 to 1 for operations like `Get`, `Iterator.Key` and `Iterator.Values`. `Put` makes 0 heap allocations now.

```
name                      old time/op    new time/op    delta
DBGets/multiple-Get()s-4  10.4ms ± 2%    9.3ms ± 3%     -10.88%  (p=0.008 n=5+5)

name                      old speed      new speed      delta
DBGets/multiple-Get()s-4  19.2MB/s ± 2%  21.5MB/s ± 3%  +12.23%  (p=0.008 n=5+5)

name                      old alloc/op   new alloc/op   delta
DBGets/multiple-Get()s-4  1.60MB ± 0%    1.28MB ± 0%    -20.01%  (p=0.000 n=4+5)

name                      old allocs/op  new allocs/op  delta
DBGets/multiple-Get()s-4  40.0k ± 0%     10.0k ± 0%     -75.00%  (p=0.008 n=5+5)
```