### PR TITLE
Add PutMany

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.out
 _testmain.go
 _obj
+.idea
+*.iml

--- a/db.go
+++ b/db.go
@@ -178,8 +178,6 @@ func (db *DB) Put(wo *WriteOptions, key, value []byte) error {
 //
 // Under the hood, this creates a write batch, adds the key/values to it and then writes it to the db.  This avoids
 // multiple cgo calls if you want to add a lot of items to a write batch at once.
-//
-// The WriteOptions passed in can be reused by multiple calls to this and if the WriteOptions is left unchanged.
 func (db *DB) PutMany(wo *WriteOptions, keys, values [][]byte) error {
 	if db.closed {
 		panic(ErrDBClosed)

--- a/deps/leveldb/db/c.cc
+++ b/deps/leveldb/db/c.cc
@@ -178,6 +178,25 @@ char* leveldb_put(
   return err;
 }
 
+char * leveldb_putmany(
+    leveldb_t* db,
+    const leveldb_writeoptions_t* options,
+    leveldb_keyvalue_t* items,
+    size_t len) {
+
+  leveldb_writebatch_t* b = leveldb_writebatch_create();
+
+  for (int i=0; i < len; i++) {
+    b->rep.Put(Slice(items[i].key, items[i].keylen), Slice(items[i].val, items[i].vallen));
+  }
+
+  char *err = leveldb_write(db, options, b);
+
+  leveldb_writebatch_destroy(b);
+
+  return err;
+}
+
 char* leveldb_delete(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,

--- a/deps/leveldb/include/leveldb/c.h
+++ b/deps/leveldb/include/leveldb/c.h
@@ -81,6 +81,19 @@ extern leveldb_openresult_t leveldb_open(
 
 extern void leveldb_close(leveldb_t* db);
 
+typedef struct {
+    const char* key;
+    size_t keylen;
+    const char* val;
+    size_t vallen;
+} leveldb_keyvalue_t;
+
+extern char * leveldb_putmany(
+    leveldb_t* db,
+    const leveldb_writeoptions_t* options,
+    leveldb_keyvalue_t* items,
+    size_t len);
+
 extern char* leveldb_put(
     leveldb_t* db,
     const leveldb_writeoptions_t* options,


### PR DESCRIPTION
This PR adds a `PutMany` function to the DB.  It allows the caller to send multiple key/values to the DB in one cgo call as opposed to 1 per k/v that you would normally get with either `Put` or a `WriteBatch`.

Under the hood, this instantiates a write batch, adds the kvs to it and writes it to the DB.

Benchmarks below comparing writing different sized keysets between `Put`, `WriteBatch` and `PutMany`. Its about ~12% faster than using a plain `WriteBatch` for our target workload of 10k keys:

```
$ go test -run=NONE -bench=BenchmarkDB_Put -benchmem
goos: linux
goarch: amd64
pkg: github.com/DataDog/leveldb
BenchmarkDB_Put/Put_1000-2         	    1000	   2173604 ns/op	  12.88 MB/s	      33 B/op	       1 allocs/op
BenchmarkDB_Put/Batch_1000-2       	    2000	    728948 ns/op	  38.41 MB/s	      20 B/op	       1 allocs/op
BenchmarkDB_Put/PutMany_1000-2     	    2000	    681249 ns/op	  41.10 MB/s	      20 B/op	       1 allocs/op
BenchmarkDB_Put/Put_10000-2        	     100	  23391943 ns/op	  11.97 MB/s	     262 B/op	       1 allocs/op
BenchmarkDB_Put/Batch_10000-2      	     200	   7918311 ns/op	  35.36 MB/s	     134 B/op	       1 allocs/op
BenchmarkDB_Put/PutMany_10000-2    	     200	   6894216 ns/op	  40.61 MB/s	     134 B/op	       1 allocs/op
BenchmarkDB_Put/Put_10000#01-2     	     100	  23943452 ns/op	  11.69 MB/s	     262 B/op	       1 allocs/op
BenchmarkDB_Put/Batch_10000#01-2   	     200	   8423355 ns/op	  33.24 MB/s	     134 B/op	       1 allocs/op
BenchmarkDB_Put/PutMany_10000#01-2 	     200	   7896997 ns/op	  35.46 MB/s	     134 B/op	       1 allocs/op
PASS
ok  	github.com/DataDog/leveldb	19.648s
```

Thank you @akrylysov for the help with the cgo bits.

cc: @DataDog/burrito 