### PR TITLE
cgo_flags_common.go: remove -lpthread: Included by Cgo

### DIFF
--- a/cgo_flags_common.go
+++ b/cgo_flags_common.go
@@ -1,6 +1,7 @@
 package levigo
 
-// #cgo CFLAGS: -I${SRCDIR}/deps/lz4 -I${SRCDIR}/deps/leveldb/include -fno-builtin-memcmp -O2 -DLEVELDB_PLATFORM_POSIX -DLEVELDB_ATOMIC_PRESENT
-// #cgo CXXFLAGS: -I${SRCDIR}/deps/lz4 -I${SRCDIR}/deps/leveldb/include -I${SRCDIR}/deps/leveldb -std=c++11 -fno-builtin-memcmp -O2 -lpthread -DLEVELDB_PLATFORM_POSIX -DLEVELDB_ATOMIC_PRESENT
+// #cgo CFLAGS: -I${SRCDIR}/deps/lz4 -I${SRCDIR}/deps/leveldb/include -fno-builtin-memcmp -g -O2 -DLEVELDB_PLATFORM_POSIX -DLEVELDB_ATOMIC_PRESENT
+// #cgo CXXFLAGS: -I${SRCDIR}/deps/lz4 -I${SRCDIR}/deps/leveldb/include -I${SRCDIR}/deps/leveldb -std=c++11 -fno-builtin-memcmp -g -O2 -DLEVELDB_PLATFORM_POSIX -DLEVELDB_ATOMIC_PRESENT
+// #cgo LDFLAGS: -lpthread
 // #include "leveldb/c.h"
 import "C"

--- a/cgo_snappy_common.go
+++ b/cgo_snappy_common.go
@@ -1,5 +1,5 @@
 package levigo
 
 // #cgo CFLAGS: -I${SRCDIR}/deps/snappy -DSNAPPY
-// #cgo CXXFLAGS: -I${SRCDIR}/deps/snappy -std=c++11 -g -O2 -fPIC -DPIC -DSNAPPY
+// #cgo CXXFLAGS: -I${SRCDIR}/deps/snappy -DPIC -DSNAPPY
 import "C"


### PR DESCRIPTION
This fixes the following build error:

    invalid flag in #cgo CXXFLAGS: -lpthread

This occurs because each of the Cgo compiler settings has a list of
acceptable flags, to try and make it harder to execute arbitrary
code when someone runs "go get". The -l flag is not permitted in
CXXFLAGS, but is in LDFLAGS.

cgo_snappy_common.go: cgo concatenates all #cgo directions in all .go
files. This means we were passing compiler flags multiple times.
Simplify the configuration to only pass flags once. This file had
many flags that were already specified in cgo_flags_common.go.